### PR TITLE
Update typescript definition for Nuxt 2.9+

### DIFF
--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -26,6 +26,21 @@ declare module '@nuxt/vue-app' {
   }
 }
 
+// Nuxt 2.9+
+declare module '@nuxt/types' {
+  interface NuxtAppOptions {
+    isDesktop: boolean
+    isIos: boolean
+    isAndroid: boolean
+    isMobile: boolean
+    isMobileOrTablet: boolean
+    isDesktopOrTablet: boolean
+    isTablet: boolean
+    isWindows: boolean
+    isMacOS: boolean
+  }
+}
+
 declare module 'vue/types/vue' {
   interface Vue {
     $device: Device


### PR DESCRIPTION
The guide of migration 2.8 to 2.9: https://typescript.nuxtjs.org/migration.html