### PR TITLE
docs: add types configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,20 @@ Add it to the `buildModules` section of your `nuxt.config`:
 
 That's it, you can now use `$device` in your [Nuxt](https://nuxtjs.org) app ✨
 
+## TypeScript support
+
+Add the types to your `"types"` array in `tsconfig.json` after the `@nuxt/types` entry.
+
+:warning: Use `@nuxt/vue-app` instead of `@nuxt/types` for nuxt < 2.9.
+
+```json
+{
+  "compilerOptions": {
+    "types": ["@nuxt/types", "@nuxtjs/device"]
+  }
+}
+```
+
 ## Flags
 
 You can use these flags to detect the device type.


### PR DESCRIPTION
I was using this module with typescript and I realized that the types exist and can be used correctly but they are not in the documentation.