### PR TITLE
export Device interface

### DIFF
--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 
-interface Device {
+export interface Device {
   userAgent: string
   isDesktop: boolean
   isIos: boolean


### PR DESCRIPTION
After I upgraded my project's `@nuxt/eslint-config-typescript` and `eslint-plugin-nuxt`(v7.0.2 and v3.0.0, respectively), it starts complaining about `import/named` rule violation.

So I propose exporting Device interface.
This is necessary when you want to add extra flags to Device interface.