### PR TITLE
docs: add isSafari

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ $device.isAndroid
 $device.isFirefox
 $device.isEdge
 $device.isChrome
+$device.isSafari
 $device.isSamsung
 $device.isCrawler
 ```


### PR DESCRIPTION
The `isSafari` flag is missing from the readme.