### PR TITLE
[CloudFront] Extend device type detection and add tests

### DIFF
--- a/src/runtime/generateFlags.ts
+++ b/src/runtime/generateFlags.ts
@@ -73,6 +73,16 @@ export default function generateFlags (headers, userAgent: string): Device {
       mobile = false
       mobileOrTablet = true
     }
+    if (headers['cloudfront-is-desktop-viewer'] === 'true') {
+      mobile = false
+      mobileOrTablet = false
+    }
+    if (headers['cloudfront-is-ios-viewer'] === 'true') {
+      ios = true
+    }
+    if (headers['cloudfront-is-android-viewer'] === 'true') {
+      android = true
+    }
   } else if (headers && headers['cf-device-type']) { // Cloudflare
     switch (headers['cf-device-type']) {
       case 'mobile':

--- a/test/module.test.ts
+++ b/test/module.test.ts
@@ -320,9 +320,9 @@ describe('ssr', async () => {
         'cf-device-type': 'desktop'
       }
     })
-    const { isMobile, isMobileOrTablet } = parseHtml(html)
+    const { isDesktop } = parseHtml(html)
 
-    expect({ isMobile, isMobileOrTablet }).toEqual({ isMobile: false, isMobileOrTablet: false })
+    expect(isDesktop).toEqual(true)
   })
 
   it('detects crawlers - googlebots', async () => {
@@ -347,6 +347,7 @@ describe('ssr', async () => {
       }
     })
     const { isCrawler } = parseHtml(html)
+
     expect(isCrawler).toEqual(true)
   })
 
@@ -359,6 +360,7 @@ describe('ssr', async () => {
       }
     })
     const { isCrawler } = parseHtml(html)
+
     expect(isCrawler).toEqual(true)
   })
 })

--- a/test/module.test.ts
+++ b/test/module.test.ts
@@ -232,6 +232,42 @@ describe('ssr', async () => {
     })
   })
 
+  it('detects cloudfront headers - desktop', async () => {
+    const html = await $fetch('/', {
+      headers: {
+        'User-Agent': 'Amazon CloudFront',
+        'Cloudfront-Is-Desktop-Viewer': 'true'
+      }
+    })
+    const { isDesktop } = parseHtml(html)
+
+    expect(isDesktop).toEqual(true)
+  })
+
+  it('detects cloudfront headers - ios', async () => {
+    const html = await $fetch('/', {
+      headers: {
+        'User-Agent': 'Amazon CloudFront',
+        'Cloudfront-Is-Ios-Viewer': 'true'
+      }
+    })
+    const { isIos } = parseHtml(html)
+
+    expect(isIos).toEqual(true)
+  })
+
+  it('detects cloudfront headers - android', async () => {
+    const html = await $fetch('/', {
+      headers: {
+        'User-Agent': 'Amazon CloudFront',
+        'Cloudfront-Is-Android-Viewer': 'true'
+      }
+    })
+    const { isAndroid } = parseHtml(html)
+
+    expect(isAndroid).toEqual(true)
+  })
+
   it('detects cloudflare headers - mobile', async () => {
     const html = await $fetch('/', {
       headers: {

--- a/test/module.test.ts
+++ b/test/module.test.ts
@@ -232,6 +232,30 @@ describe('ssr', async () => {
     })
   })
 
+  it('detects cloudfront headers - mobile', async () => {
+    const html = await $fetch('/', {
+      headers: {
+        'User-Agent': 'Amazon CloudFront',
+        'Cloudfront-Is-Mobile-Viewer': 'true'
+      }
+    })
+    const { isMobile, isMobileOrTablet } = parseHtml(html)
+
+    expect({ isMobile, isMobileOrTablet }).toEqual({ isMobile: true, isMobileOrTablet: true })
+  })
+
+  it('detects cloudfront headers - tablet', async () => {
+    const html = await $fetch('/', {
+      headers: {
+        'User-Agent': 'Amazon CloudFront',
+        'Cloudfront-Is-Tablet-Viewer': 'true'
+      }
+    })
+    const { isMobile, isMobileOrTablet } = parseHtml(html)
+
+    expect({ isMobile, isMobileOrTablet }).toEqual({ isMobile: false, isMobileOrTablet: true })
+  })
+
   it('detects cloudfront headers - desktop', async () => {
     const html = await $fetch('/', {
       headers: {


### PR DESCRIPTION
#### 🔍 Context
Closes #132 - Add support for 3 Amazon CloudFront headers : 
- `cloudfront-is-desktop-viewer`
- `cloudfront-is-ios-viewer`
- `cloudfront-is-android-viewer`
#### 🏗 Work
- [x] Add detection for the following device types : desktop, iOS, Android.

#### 🗒 Notes
Adding this bit of logic to the `v2.*.*` tree would be _very much appreciated_ as I actually need this for Nuxt 2 🙏 