### PR TITLE
feat: enable to extend custom flag types

### DIFF
--- a/src/runtime/types/index.d.ts
+++ b/src/runtime/types/index.d.ts
@@ -1,4 +1,4 @@
-export type Device = {
+export interface Device {
     userAgent: string
     isDesktop: boolean
     isIos: boolean
@@ -16,4 +16,4 @@ export type Device = {
     isChrome: boolean
     isSamsung: boolean
     isCrawler: boolean
-  }
+  } 


### PR DESCRIPTION
```typescript
declare module '@nuxtjs/device/dist/runtime/types' {
  interface Device {
    isMyApp: boolean
  }
}
```