### PR TITLE
chore: export runtime, close #154

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,11 @@
     ".": {
       "import": "./dist/module.mjs",
       "require": "./dist/module.cjs"
+    },
+    "./runtime/*": {
+      "import": "./dist/runtime/*.mjs",
+      "require": "./dist/runtime/*.cjs",
+      "types": "./dist/runtime/*.d.ts"
     }
   },
   "main": "./dist/module.cjs",


### PR DESCRIPTION
We should export the contents of the runtime, which makes the module compatible with more scenarios。

for example 👇

```ts
import generateFlags from "@nuxtjs/device/runtime/generateFlags";
```

Related issue: #154 