### PR TITLE
[Types] Export `Device` interface from `types.d.ts` (v2)

### DIFF
--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 
-interface Device {
+export interface Device {
   userAgent: string
   isDesktop: boolean
   isIos: boolean


### PR DESCRIPTION
## 🔍 Context
Closes #159 

Sometimes, declaring modules is not enough.

https://github.com/nuxt-community/device-module/blob/aa0f6967cc15885bb2bdce9f677f278d31a8a4c6/lib/types.d.ts#L22-L52

Having the interface exported would help declaring mocks, for example.
## 🎯 Goal
Export `Device` interface
## 🏗 Work
- [x] Export `Device` from `types.d.ts`
## 🗒 Notes
[V3 exports it as well](https://github.com/nuxt-community/device-module/blob/c88dcdb6f2610e7c417519043e13502c98af711f/src/runtime/types/index.d.ts)